### PR TITLE
Swap movie lists to FlashList for smoother scrolling

### DIFF
--- a/apps/mobile/app/(tabs)/discover/index.tsx
+++ b/apps/mobile/app/(tabs)/discover/index.tsx
@@ -49,6 +49,7 @@ export default function DiscoverScreen() {
 					{ paddingBottom: spacing[8] + insets.bottom },
 				]}
 				keyboardShouldPersistTaps="handled"
+				directionalLockEnabled
 				refreshControl={
 					<RefreshControl
 						refreshing={refreshing}

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -11,7 +11,7 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { EmptyState } from "@/components/empty-state";
-import { MoviePoster } from "@/components/movie-poster";
+import { HorizontalMovieList } from "@/components/horizontal-movie-list";
 import { UserAvatar } from "@/components/user-avatar";
 import { useSession } from "@/lib/auth";
 import { Colors, fontFamily, fontSize, radius, spacing } from "@/lib/constants";
@@ -120,22 +120,12 @@ export default function HomeScreen() {
 									</View>
 								</View>
 
-								<ScrollView
-									horizontal
-									showsHorizontalScrollIndicator={false}
-									contentContainerStyle={styles.posterRow}
-								>
-									{friend.matches.map((m) => (
-										<MoviePoster
-											key={m.id}
-											id={m.id}
-											posterPath={m.posterPath}
-											title={m.title}
-											width={100}
-											height={150}
-										/>
-									))}
-								</ScrollView>
+								<HorizontalMovieList
+									movies={friend.matches}
+									posterWidth={100}
+									posterHeight={150}
+									contentPaddingHorizontal={0}
+								/>
 							</Pressable>
 						))}
 					</View>
@@ -204,8 +194,5 @@ const styles = StyleSheet.create({
 	matchCount: {
 		fontSize: fontSize.xs,
 		color: Colors.mutedForeground,
-	},
-	posterRow: {
-		gap: spacing[3],
 	},
 });

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -24,6 +24,7 @@
 		"@miru/analytics": "workspace:*",
 		"@react-navigation/native": "7.2.2",
 		"@sentry/react-native": "7.13.0",
+		"@shopify/flash-list": "2.0.2",
 		"@tanstack/react-query": "catalog:trpc",
 		"@trpc/client": "catalog:trpc",
 		"@trpc/react-query": "catalog:trpc",

--- a/apps/mobile/src/components/horizontal-movie-list.tsx
+++ b/apps/mobile/src/components/horizontal-movie-list.tsx
@@ -1,0 +1,67 @@
+import { useCallback, useMemo } from "react";
+import { View } from "react-native";
+import { FlashList, type ListRenderItem } from "@shopify/flash-list";
+import { MoviePoster } from "./movie-poster";
+import { spacing } from "@/lib/constants";
+import type { MovieSummary } from "@/lib/types";
+
+interface HorizontalMovieListProps {
+	movies: MovieSummary[];
+	posterWidth?: number;
+	posterHeight?: number;
+	gap?: number;
+	contentPaddingHorizontal?: number;
+}
+
+const keyExtractor = (item: MovieSummary) => String(item.id);
+
+export function HorizontalMovieList({
+	movies,
+	posterWidth = 120,
+	posterHeight = 180,
+	gap = spacing[3],
+	contentPaddingHorizontal = spacing[4],
+}: HorizontalMovieListProps) {
+	const renderItem: ListRenderItem<MovieSummary> = useCallback(
+		({ item }) => (
+			<MoviePoster
+				id={item.id}
+				posterPath={item.posterPath}
+				title={item.title}
+				width={posterWidth}
+				height={posterHeight}
+				transition={0}
+			/>
+		),
+		[posterWidth, posterHeight],
+	);
+
+	const ItemSeparator = useCallback(
+		() => <View style={{ width: gap }} />,
+		[gap],
+	);
+
+	const wrapperStyle = useMemo(
+		() => ({ height: posterHeight }),
+		[posterHeight],
+	);
+	const contentContainerStyle = useMemo(
+		() => ({ paddingHorizontal: contentPaddingHorizontal }),
+		[contentPaddingHorizontal],
+	);
+
+	return (
+		<View style={wrapperStyle}>
+			<FlashList
+				data={movies}
+				keyExtractor={keyExtractor}
+				renderItem={renderItem}
+				ItemSeparatorComponent={ItemSeparator}
+				horizontal
+				showsHorizontalScrollIndicator={false}
+				contentContainerStyle={contentContainerStyle}
+				decelerationRate="fast"
+			/>
+		</View>
+	);
+}

--- a/apps/mobile/src/components/movie-carousel.tsx
+++ b/apps/mobile/src/components/movie-carousel.tsx
@@ -1,5 +1,5 @@
-import { View, Text, FlatList, StyleSheet } from "react-native";
-import { MoviePoster } from "./movie-poster";
+import { View, Text, StyleSheet } from "react-native";
+import { HorizontalMovieList } from "./horizontal-movie-list";
 import { Colors, fontSize, fontFamily, spacing } from "@/lib/constants";
 import type { MovieSummary } from "@/lib/types";
 
@@ -16,20 +16,7 @@ export function MovieCarousel({ title, movies }: MovieCarouselProps) {
 	return (
 		<View style={styles.container}>
 			<Text style={styles.title}>{title}</Text>
-			<FlatList
-				data={movies}
-				keyExtractor={(item) => String(item.id)}
-				horizontal
-				showsHorizontalScrollIndicator={false}
-				contentContainerStyle={styles.list}
-				renderItem={({ item }) => (
-					<MoviePoster
-						id={item.id}
-						posterPath={item.posterPath}
-						title={item.title}
-					/>
-				)}
-			/>
+			<HorizontalMovieList movies={movies} />
 		</View>
 	);
 }
@@ -43,9 +30,5 @@ const styles = StyleSheet.create({
 		fontFamily: fontFamily.sansSemibold,
 		color: Colors.foreground,
 		paddingHorizontal: spacing[4],
-	},
-	list: {
-		paddingHorizontal: spacing[4],
-		gap: spacing[3],
 	},
 });

--- a/apps/mobile/src/components/movie-grid.tsx
+++ b/apps/mobile/src/components/movie-grid.tsx
@@ -1,5 +1,6 @@
-import { FlatList, StyleSheet, View, RefreshControl } from "react-native";
-import { useState } from "react";
+import { useCallback, useState } from "react";
+import { RefreshControl, StyleSheet, View } from "react-native";
+import { FlashList, type ListRenderItem } from "@shopify/flash-list";
 import { MoviePoster } from "./movie-poster";
 import { MovieGridSkeleton } from "./movie-grid-skeleton";
 import { Spinner } from "./spinner";
@@ -20,6 +21,21 @@ interface MovieGridProps {
 
 const NUM_COLUMNS = 3;
 const ITEM_GAP = spacing[2];
+const HALF_GAP = ITEM_GAP / 2;
+
+const keyExtractor = (item: MovieSummary) => String(item.id);
+
+const renderItem: ListRenderItem<MovieSummary> = ({ item }) => (
+	<View style={styles.item}>
+		<MoviePoster
+			id={item.id}
+			posterPath={item.posterPath}
+			title={item.title}
+			width="100%"
+			aspectRatio={2 / 3}
+		/>
+	</View>
+);
 
 export function MovieGrid({
 	movies,
@@ -33,13 +49,13 @@ export function MovieGrid({
 }: MovieGridProps) {
 	const [refreshing, setRefreshing] = useState(false);
 
-	function handleEndReached() {
+	const handleEndReached = useCallback(() => {
 		if (fetchNextPage && hasNextPage && !isFetchingNextPage) {
 			fetchNextPage();
 		}
-	}
+	}, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
-	async function handleRefresh() {
+	const handleRefresh = useCallback(async () => {
 		if (!onRefresh) {
 			return;
 		}
@@ -51,24 +67,20 @@ export function MovieGrid({
 		} finally {
 			setRefreshing(false);
 		}
-	}
+	}, [onRefresh]);
 
 	return (
-		<FlatList
+		<FlashList
 			data={movies}
-			keyExtractor={(item) => String(item.id)}
+			keyExtractor={keyExtractor}
+			renderItem={renderItem}
 			numColumns={NUM_COLUMNS}
 			contentContainerStyle={styles.list}
-			columnWrapperStyle={styles.row}
 			contentInsetAdjustmentBehavior="automatic"
 			showsVerticalScrollIndicator={false}
 			alwaysBounceVertical={movies.length > 0}
 			onEndReached={handleEndReached}
 			onEndReachedThreshold={0.5}
-			removeClippedSubviews
-			initialNumToRender={9}
-			maxToRenderPerBatch={9}
-			windowSize={5}
 			ListEmptyComponent={
 				isLoading ? <MovieGridSkeleton /> : ListEmptyComponent
 			}
@@ -89,34 +101,18 @@ export function MovieGrid({
 					/>
 				) : undefined
 			}
-			renderItem={({ item }) => (
-				<View style={styles.item}>
-					<MoviePoster
-						id={item.id}
-						posterPath={item.posterPath}
-						title={item.title}
-						width="100%"
-						aspectRatio={2 / 3}
-					/>
-				</View>
-			)}
 		/>
 	);
 }
 
 const styles = StyleSheet.create({
 	list: {
-		paddingHorizontal: spacing[4],
+		paddingHorizontal: spacing[4] - HALF_GAP,
 		paddingBottom: spacing[8],
-		flexGrow: 1,
-	},
-	row: {
-		gap: ITEM_GAP,
 	},
 	item: {
 		flex: 1,
-		maxWidth: `${100 / NUM_COLUMNS}%`,
-		marginBottom: ITEM_GAP,
+		padding: HALF_GAP,
 	},
 	footer: {
 		paddingVertical: spacing[4],

--- a/apps/mobile/src/components/movie-poster.tsx
+++ b/apps/mobile/src/components/movie-poster.tsx
@@ -17,6 +17,7 @@ interface MoviePosterProps {
 	width?: number | "100%";
 	height?: number;
 	aspectRatio?: number;
+	transition?: number;
 }
 
 export function MoviePoster({
@@ -26,6 +27,7 @@ export function MoviePoster({
 	width = 120,
 	height,
 	aspectRatio,
+	transition = 200,
 }: MoviePosterProps) {
 	const sizeStyle = aspectRatio
 		? { width, aspectRatio }
@@ -46,7 +48,7 @@ export function MoviePoster({
 					style={[styles.image, sizeStyle]}
 					contentFit="cover"
 					recyclingKey={`poster-${id}`}
-					transition={200}
+					transition={transition}
 				/>
 			) : (
 				<View style={[styles.placeholder, sizeStyle]}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       '@sentry/react-native':
         specifier: 7.13.0
         version: 7.13.0(expo@55.0.15)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
+      '@shopify/flash-list':
+        specifier: 2.0.2
+        version: 2.0.2(@babel/runtime@7.28.6)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
       '@tanstack/react-query':
         specifier: catalog:trpc
         version: 5.96.2(react@19.2.5)
@@ -4154,6 +4157,13 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       webpack: '>=5.0.0'
+
+  '@shopify/flash-list@2.0.2':
+    resolution: {integrity: sha512-zhlrhA9eiuEzja4wxVvotgXHtqd3qsYbXkQ3rsBfOgbFA9BVeErpDE/yEwtlIviRGEqpuFj/oU5owD6ByaNX+w==}
+    peerDependencies:
+      '@babel/runtime': '*'
+      react: '*'
+      react-native: '*'
 
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
@@ -12402,6 +12412,13 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@shopify/flash-list@2.0.2(@babel/runtime@7.28.6)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      react: 19.2.5
+      react-native: 0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5)
+      tslib: 2.8.1
 
   '@sinclair/typebox@0.27.10': {}
 


### PR DESCRIPTION
## Summary
Horizontal movie carousels felt a bit glitchy while scrolling. Swapped the FlatList/ScrollView usages over to FlashList and cut the per-poster fade-in during scroll. While in here I pulled the horizontal poster row out into a shared `HorizontalMovieList` so the discover carousels and the home screen's friend-match rows use the same thing, and switched the vertical movie grid to FlashList too.