### PR TITLE
fix(web): onboarding warnings and stuck friends step

### DIFF
--- a/apps/web/src/app/(onboarding)/onboarding/onboarding-client.tsx
+++ b/apps/web/src/app/(onboarding)/onboarding/onboarding-client.tsx
@@ -30,9 +30,11 @@ interface OnboardingClientProps {
 
 export function OnboardingClient({ initialName }: OnboardingClientProps) {
 	const router = useRouter();
-	const steps: readonly StepName[] = initialName.trim()
-		? ["region", "genre", "streaming", "watchlist", "friends"]
-		: ["profile", "region", "genre", "streaming", "watchlist", "friends"];
+	const [steps] = useState<readonly StepName[]>(() =>
+		initialName.trim()
+			? ["region", "genre", "streaming", "watchlist", "friends"]
+			: ["profile", "region", "genre", "streaming", "watchlist", "friends"],
+	);
 	const totalSteps = steps.length;
 
 	const [step, setStep] = useState(1);

--- a/apps/web/src/app/(onboarding)/onboarding/steps/genre-step.tsx
+++ b/apps/web/src/app/(onboarding)/onboarding/steps/genre-step.tsx
@@ -37,16 +37,14 @@ export function GenreStep({
 	const isEmpty = !isLoading && !error && (genres?.length ?? 0) === 0;
 
 	const toggle = (id: number) => {
-		setSelected((prev) => {
-			const next = new Set(prev);
-			if (next.has(id)) {
-				next.delete(id);
-			} else {
-				next.add(id);
-			}
-			onSelectionChange(Array.from(next));
-			return next;
-		});
+		const next = new Set(selected);
+		if (next.has(id)) {
+			next.delete(id);
+		} else {
+			next.add(id);
+		}
+		setSelected(next);
+		onSelectionChange(Array.from(next));
 	};
 
 	return (

--- a/apps/web/src/app/(onboarding)/onboarding/steps/watchlist-step.tsx
+++ b/apps/web/src/app/(onboarding)/onboarding/steps/watchlist-step.tsx
@@ -95,7 +95,7 @@ export function WatchlistStep({ genreIds, onComplete }: WatchlistStepProps) {
 									isAdded && "ring-2 ring-primary",
 								)}
 							>
-								<div className="aspect-[2/3] bg-muted">
+								<div className="relative aspect-[2/3] bg-muted">
 									{movie.posterPath ? (
 										<Image
 											src={`https://image.tmdb.org/t/p/w342${movie.posterPath}`}

--- a/apps/web/src/components/movie-poster.tsx
+++ b/apps/web/src/components/movie-poster.tsx
@@ -29,7 +29,7 @@ export function MoviePoster({
 				className,
 			)}
 		>
-			<div className="aspect-[2/3] bg-muted">
+			<div className="relative aspect-[2/3] bg-muted">
 				{posterPath ? (
 					<Image
 						src={`https://image.tmdb.org/t/p/w500${posterPath}`}


### PR DESCRIPTION
- **Next.js `<Image fill>` warnings** — added `relative` to the `aspect-[2/3]` wrapper in `MoviePoster` and the onboarding `WatchlistStep`. The fill image needs a positioned parent. Kills the warning across discover, dashboard, and the watchlist step.
- **GenreStep setState-in-render** — was calling `onSelectionChange` from inside the `setSelected` updater, which triggers the parent (`OnboardingClient`) to setState while `GenreStep` is rendering. Moved the parent notification outside the updater. Kills the *"Cannot update a component (OnboardingClient) while rendering a different component (GenreStep)"* console error.
- **Friends step "stuck" bug** — root cause: `FollowButton.onSettled` calls `router.refresh()`, which re-runs the server component. If the user's name was empty at sign-in but got set during the profile step, `session.user.name` on refresh returns the new name, so `initialName` flips from `""` to a value. `OnboardingClient` was re-deriving `steps` from that prop on every render — so the array shrinks from 6 to 5 mid-flow, `step` is now out of bounds, `currentStepName` is `undefined`, and the body renders `null` while the stepper + disabled Finish stay visible. Froze `steps` on mount with `useState` so it can't change after the flow starts.