### PR TITLE
chore(deps): pnpm 11.6.0 + @vercel/blob 2.4.0

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,7 +23,7 @@
 		"@trpc/react-query": "catalog:trpc",
 		"@trpc/server": "catalog:trpc",
 		"@upstash/qstash": "catalog:",
-		"@vercel/blob": "2.3.3",
+		"@vercel/blob": "2.4.0",
 		"@vercel/speed-insights": "2.0.0",
 		"better-auth": "catalog:better-auth",
 		"class-variance-authority": "0.7.1",

--- a/package.json
+++ b/package.json
@@ -34,5 +34,5 @@
 	"engines": {
 		"node": ">=24.14.0"
 	},
-	"packageManager": "pnpm@11.1.3"
+	"packageManager": "pnpm@11.6.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,8 +334,8 @@ importers:
         specifier: 'catalog:'
         version: 2.11.0
       '@vercel/blob':
-        specifier: 2.3.3
-        version: 2.3.3
+        specifier: 2.4.0
+        version: 2.4.0
       '@vercel/speed-insights':
         specifier: 2.0.0
         version: 2.0.0(next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
@@ -4071,8 +4071,8 @@ packages:
   '@upstash/redis@1.38.0':
     resolution: {integrity: sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==}
 
-  '@vercel/blob@2.3.3':
-    resolution: {integrity: sha512-MtD7VLo6hU07eHR7bmk5SIMD290q574UaNYTe46qeyRT+hWrCy26CoAqfd7PnIefVXvRehRZBzukxuTO9iGTVg==}
+  '@vercel/blob@2.4.0':
+    resolution: {integrity: sha512-ncQ8CRb6XoEAYJwjOTRGpACRT6h/AeY+/33gLyeVxG5BIes27OPm1jmqreF+JHjcTmGhClTP+kBpmyLfbV0xew==}
     engines: {node: '>=20.0.0'}
 
   '@vercel/speed-insights@2.0.0':
@@ -10760,7 +10760,7 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/blob@2.3.3':
+  '@vercel/blob@2.4.0':
     dependencies:
       async-retry: 1.3.3
       is-buffer: 2.0.5


### PR DESCRIPTION
Combines Renovate #769 (pnpm 11.1.3→11.6.0) and #770 (@vercel/blob 2.3.3→2.4.0). Lockfile regenerated with pnpm 11.6.0 via corepack. `pnpm check` passes. Admin-merged.