### PR TITLE
chore(renovate): respect pnpm 24h release-age gate + pin async-storage to SDK

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,8 @@
 		"enabled": true
 	},
 	"postUpdateOptions": ["pnpmDedupe"],
+	"minimumReleaseAge": "3 days",
+	"internalChecksFilter": "strict",
 	"prHourlyLimit": 0,
 	"packageRules": [
 		{
@@ -83,7 +85,8 @@
 				"react-native-screens",
 				"react-native-safe-area-context",
 				"react-native-svg",
-				"react-native-web"
+				"react-native-web",
+				"@react-native-async-storage/async-storage"
 			],
 			"matchUpdateTypes": ["major", "minor"],
 			"enabled": false


### PR DESCRIPTION
## Why
Every fresh Renovate dep PR was failing CI with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`. Cause: pnpm 11's built-in **24h minimumReleaseAge** supply-chain gate rejects packages published <24h ago, but Renovate opens PRs the instant a version publishes — so CI stays red for ~a day until the package ages.

## Fix
- **`minimumReleaseAge: "3 days"` + `internalChecksFilter: "strict"`** — Renovate holds updates until they're old enough to clear pnpm's gate (3-day buffer over the 24h gate; also a mild supply-chain safety win). PRs will now be green on arrival.
- **Pin `@react-native-async-storage/async-storage`** to the Expo-SDK native-module list (disable major/minor) so the v3 PR (#735/#779) stops being recreated — SDK 56 bundles 2.2.0.

Config validated with `renovate-config-validator` ✅. No dependency/lockfile changes.